### PR TITLE
Add Exn Expression Support

### DIFF
--- a/Cilsil/Cil/Parsers/ExceptionParser.cs
+++ b/Cilsil/Cil/Parsers/ExceptionParser.cs
@@ -136,7 +136,7 @@ namespace Cilsil.Cil.Parsers
                         break;
                     }
                 }
-                state.PushExpr(new VarExpression(returnVariable), expressionType);
+                state.PushExpr(new ExnExpression(new VarExpression(returnVariable)), expressionType);
 
                 if (nextInstructionIfNoException != null)
                 {

--- a/Cilsil/Cil/Parsers/ExceptionParser.cs
+++ b/Cilsil/Cil/Parsers/ExceptionParser.cs
@@ -164,7 +164,7 @@ namespace Cilsil.Cil.Parsers
                 
                 // The first copy of this stack item was popped in the invocation of the
                 // constructor, so we push another on.
-                state.PushExpr(new VarExpression(fieldIdentifier), fieldType);
+                state.PushExpr(new ExnExpression(new VarExpression(fieldIdentifier)), fieldType);
                 state.PushInstruction(instruction, newNode);
             }
             // Construct a finally block when unwrapped exception type is "System.Object".

--- a/Cilsil/Cil/Parsers/ExceptionParser.cs
+++ b/Cilsil/Cil/Parsers/ExceptionParser.cs
@@ -164,7 +164,7 @@ namespace Cilsil.Cil.Parsers
                 
                 // The first copy of this stack item was popped in the invocation of the
                 // constructor, so we push another on.
-                state.PushExpr(new ExnExpression(new VarExpression(fieldIdentifier)), fieldType);
+                state.PushExpr(new VarExpression(fieldIdentifier), fieldType);
                 state.PushInstruction(instruction, newNode);
             }
             // Construct a finally block when unwrapped exception type is "System.Object".

--- a/Cilsil/Sil/Expressions/ExnExpression.cs
+++ b/Cilsil/Sil/Expressions/ExnExpression.cs
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 
 namespace Cilsil.Sil.Expressions
 {
     /// <summary>
-    /// Binary operator.
+    /// Exception expression.
     /// </summary>
     [JsonObject]
     public class ExnExpression : Expression

--- a/Cilsil/Sil/Expressions/ExnExpression.cs
+++ b/Cilsil/Sil/Expressions/ExnExpression.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+
+namespace Cilsil.Sil.Expressions
+{
+    /// <summary>
+    /// Binary operator.
+    /// </summary>
+    [JsonObject]
+    public class ExnExpression : Expression
+    {
+        /// <summary>
+        /// The expression that has exception.
+        /// </summary>
+        [JsonProperty]
+        public Expression Expression { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExnExpression"/> class.
+        /// </summary>
+        /// <param name="expression">The expression that has exception.</param>
+        public ExnExpression(Expression expression)
+        {
+            Expression = expression;
+        }
+
+        /// <summary>
+        /// Converts to string.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string" /> that represents this instance.
+        /// </returns>
+        public override string ToString() => $"EXN {Expression}";
+
+        /// <summary>
+        /// Determines whether the specified <see cref="object" />, is equal to this 
+        /// instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="object" /> to compare with this 
+        /// instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; 
+        ///   otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj) =>
+            obj is ExnExpression expression &&
+            EqualityComparer<Expression>.Default.Equals(Expression, expression.Expression);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data 
+        /// structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode() => HashCode.Combine(Expression);
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="left">The left operand.</param>
+        /// <param name="right">The right operand.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(ExnExpression left, ExnExpression right) =>
+            EqualityComparer<ExnExpression>.Default.Equals(left, right);
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="left">The left operand.</param>
+        /// <param name="right">The right operand.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(ExnExpression left, ExnExpression right) =>
+            !(left == right);
+    }
+}

--- a/Cilsil/Sil/Expressions/ExnExpression.cs
+++ b/Cilsil/Sil/Expressions/ExnExpression.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Cilsil.Sil.Expressions
 {
     /// <summary>
-    /// Exception expression.
+    /// An expression representing an exception variable.
     /// </summary>
     [JsonObject]
     public class ExnExpression : Expression


### PR DESCRIPTION
Add Exn Expression support.

For the following code snippet:

```cs
catch(Exception e)
{
    return null;
}
```

Before this change, the return node of CFG is:
```
node65 preds:  succs: 66 67 exn: 59 ExceptionHandler
n$4=*&return:System.IO.StreamWriter* [Line 89];
*&return:System.IO.StreamWriter*=null [Line 89];
n$5:System.Exception*=_fun static BuiltIn.__unwrap_exception() (n$4:System.IO.StreamWriter*) [Line 89];

node66 preds: 65 succs: 68 exn: 59 MethodBody
n$6:System.Exception*=_fun static BuiltIn.__instanceof() (n$5:System.Exception*, sizeof(System.Exception, exact):void) [Line 89];
PRUNE (n$6, True) [Line 89];
*&CatchVar:System.IO.StreamWriter*=n$5 [Line 89];

node67 preds: 65 succs: 72 exn: 59 MethodBody
n$6:System.Exception*=_fun static BuiltIn.__instanceof() (n$5:System.Exception*, sizeof(System.Exception, exact):void) [Line 89];
PRUNE (!(n$6):, False) [Line 89];

node68 preds: 66 succs: 69 exn: 59 ExceptionHandler
n$8=*&CatchVar:System.Object [Line 89];
*&%2:System.Object=n$8 [Line 89];

node69 preds: 68 succs: 70 exn: 59 MethodBody
*&%1:System.Object*=null [Line 91];

node70 preds: 69 succs: 71 exn: 59 MethodBody
n$9=*&%1:System.IO.StreamWriter* [Line 93];

node71 preds: 70 succs: 58 exn: 59 ReturnStmt
*&return:System.IO.StreamWriter*=n$9 [Line 93];

node72 preds: 67 succs: 58 exn: 59 ReturnStmt
*&return:System.IO.StreamWriter*=n$5 [Line 93];
```

After this change, the return node of CFG is:
```
node65 preds:  succs: 66 67 exn: 59 ExceptionHandler
n$4=*&return:System.Object [Line 89];
*&return:System.Object=null [Line 89];
n$5:System.Exception*=_fun static BuiltIn.__unwrap_exception() (n$4:System.Object) [Line 89];

node66 preds: 65 succs: 68 exn: 59 MethodBody
n$6:System.Exception*=_fun static BuiltIn.__instanceof() (n$5:System.Exception*, sizeof(System.Exception, exact):void) [Line 89];
PRUNE (n$6, True) [Line 89];
*&CatchVar:System.Object=n$5 [Line 89];

node67 preds: 65 succs: 72 exn: 59 MethodBody
n$6:System.Exception*=_fun static BuiltIn.__instanceof() (n$5:System.Exception*, sizeof(System.Exception, exact):void) [Line 89];
PRUNE (!(n$6):, False) [Line 89];

node68 preds: 66 succs: 69 exn: 59 ExceptionHandler
n$8=*&CatchVar:System.Object [Line 89];
*&%2:System.Object=EXN n$8 [Line 89];

node69 preds: 68 succs: 70 exn: 59 MethodBody
*&%1:System.Object*=null [Line 91];

node70 preds: 69 succs: 71 exn: 59 MethodBody
n$9=*&%1:System.IO.StreamWriter* [Line 93];

node71 preds: 70 succs: 58 exn: 59 ReturnStmt
*&return:System.IO.StreamWriter*=n$9 [Line 93];

node72 preds: 67 succs: 58 exn: 59 ReturnStmt
*&return:System.IO.StreamWriter*=EXN n$5 [Line 93];
```

Here is [link](https://github.com/facebook/infer/pull/1450) of companion PR in Infer backend side