### PR TITLE
Fix null check in try block 

### DIFF
--- a/Cilsil.Test/Assets/Utils.cs
+++ b/Cilsil.Test/Assets/Utils.cs
@@ -224,6 +224,14 @@ namespace Cilsil.Test.Assets
             $"{GetString(name)} = {value};\n";
 
         /// <summary>
+        /// Generates a string representation of a variable null check.
+        /// </summary>
+        /// <param name="name">The name of the variable that has null check.</param>
+        /// <returns>String representation of the null check statement.</returns>
+        public static string NullCheck(VarName name) =>
+            $"if ({GetString(name)} == null) {{ return; }}\n";
+
+        /// <summary>
         /// Generates a string representation of instantiating a new variable.
         /// </summary>
         /// <param name="type">The type of the variable being instantiated.</param>
@@ -310,12 +318,15 @@ namespace Cilsil.Test.Assets
         /// local resource.</param>
         /// <param name="blockKind">The kind of the exception handling block used in the test case; 
         /// for example, try-catch-finally or using.</param>
+        /// <param name="doNullCheck">If <c>true</c>, add the string representation of null check;
+        /// otherwise, does not.</param>
         /// <returns>String representing the set of statements in the exception handling 
         /// block.</returns>
         public static string InitBlock(VarType resourceLocalVarType = VarType.None,
                                        string resourceLocalVarValue = null,
                                        string disposeResource = null,
-                                       BlockKind blockKind = BlockKind.None)
+                                       BlockKind blockKind = BlockKind.None,
+                                       bool doNullCheck = false)
         {
             string output;
             var resourceInit = Declare(resourceLocalVarType, VarName.FirstLocal);
@@ -370,6 +381,9 @@ namespace Cilsil.Test.Assets
                         resourceLocalVarValue == null ? string.Empty 
                                                       : Assign(VarName.FirstLocal,
                                                                resourceLocalVarValue);
+                    tryBlockCode += 
+                        doNullCheck ? NullCheck(VarName.FirstLocal)
+                                    : string.Empty;
                     output =
                         $@"{resourceInit}
                         try

--- a/Cilsil.Test/E2E/InferSharpTest.cs
+++ b/Cilsil.Test/E2E/InferSharpTest.cs
@@ -238,16 +238,16 @@ namespace Cilsil.Test.E2E
         }
 
         /// <summary>
-        /// Validates that a null dereference on a variable in exception handling blocks 
-        /// is identified. 
+        /// Validates that a null dereference on a variable in exception handling blocks
+        /// without null check is identified. 
         /// </summary>
-        /// <param name="doNullCheck">If <c>true</c>, add null check block; otherwise,
+        /// <param name="doNullCheck">If <c>true</c>, add null check block in try block; otherwise,
         /// does not.</param>
         /// <param name="expectedError">The kind of error expected to be reported by Infer.</param>
         [DataRow(true, InferError.None)]
         [DataRow(false, InferError.NULL_DEREFERENCE)]
         [DataTestMethod]
-        public void NullDereferenceInTryBlock(bool doNullCheck, InferError expectedError)
+        public void NullDereferenceExceptionHandlingNullCheck(bool doNullCheck, InferError expectedError)
         {
             TestRunManager.Run(InitBlock(
                                     resourceLocalVarType: VarType.StreamReader,

--- a/Cilsil.Test/E2E/InferSharpTest.cs
+++ b/Cilsil.Test/E2E/InferSharpTest.cs
@@ -238,6 +238,26 @@ namespace Cilsil.Test.E2E
         }
 
         /// <summary>
+        /// Validates that a null dereference on a variable in exception handling blocks 
+        /// is identified. 
+        /// </summary>
+        /// <param name="doNullCheck">If <c>true</c>, add null check block; otherwise,
+        /// does not.</param>
+        /// <param name="expectedError">The kind of error expected to be reported by Infer.</param>
+        [DataRow(true, InferError.None)]
+        [DataRow(false, InferError.NULL_DEREFERENCE)]
+        [DataTestMethod]
+        public void NullDereferenceInTryBlock(bool doNullCheck, InferError expectedError)
+        {
+            TestRunManager.Run(InitBlock(
+                                    resourceLocalVarType: VarType.StreamReader,
+                                    disposeResource: CallMethod(VarName.FirstLocal, "Close"),
+                                    blockKind: BlockKind.TryCatchFinally,
+                                    doNullCheck: doNullCheck),
+                               GetString(expectedError));
+        }
+
+        /// <summary>
         /// Validates that a dereference on a string variable initialized to null is identified.
         /// </summary>
         /// <param name="input">The string representing the value to assign.</param>

--- a/Cilsil/Cil/Parsers/LeaveParser.cs
+++ b/Cilsil/Cil/Parsers/LeaveParser.cs
@@ -19,7 +19,8 @@ namespace Cilsil.Cil.Parsers
 
                     state.AppendToPreviousNode = false;
 
-                    if (targetTrue.Offset != nextInstruction.Offset)
+                    if (targetTrue.Offset != nextInstruction.Offset &&
+                        state.ExceptionBlockStartToEndOffsets.ContainsKey(nextInstruction.Offset))
                     {
                         state.PushRetExpr();
                         state.PushInstruction(nextInstruction);

--- a/Examples/Examples/Program.cs
+++ b/Examples/Examples/Program.cs
@@ -218,9 +218,34 @@ namespace Examples
         /// An exception handling example with null dereference error expected.
         /// </summary>
         public void NullDefExcepHandlingBad() {
-            StreamWriter stream = AllocateStreamWriter();
-            stream.WriteLine(12);
-            stream.Close();
+            StreamWriter stream = null;
+            try
+            {
+                stream.WriteLine(12);
+            }
+            finally
+            {
+                stream.Close();
+            }
+        }
+
+        /// <summary>
+        /// An exception handling example with null dereference error, no error expected.
+        /// </summary>
+        public void NullDefExcepHandlingOK() {
+            StreamWriter stream = null;
+            try
+            {
+                if (stream == null)
+                {
+                    return;
+                }
+                stream.WriteLine(12);
+            }
+            finally
+            {
+                stream.Close();
+            }
         }
 
         /// <summary>
@@ -274,10 +299,10 @@ namespace Examples
         /// </summary>
         public void ResourceLeakFilterOK() {
             StreamWriter stream = AllocateStreamWriter();
+            if (stream == null)
+                    return; 
             try 
             {
-                if (stream == null)
-                    return; 
                 stream.WriteLine(12);
             } 
             catch (Exception e) when (ExpectedIOIssue(e))

--- a/Examples/Examples/Program.cs
+++ b/Examples/Examples/Program.cs
@@ -300,7 +300,7 @@ namespace Examples
         public void ResourceLeakFilterOK() {
             StreamWriter stream = AllocateStreamWriter();
             if (stream == null)
-                    return; 
+                return; 
             try 
             {
                 stream.WriteLine(12);

--- a/Examples/Examples/Program.cs
+++ b/Examples/Examples/Program.cs
@@ -278,10 +278,10 @@ namespace Examples
         /// </summary>
         public void ResourceLeakFilterOK() {
             StreamWriter stream = AllocateStreamWriter();
-            if (stream == null)
-                return; 
             try 
             {
+                if (stream == null)
+                    return; 
                 stream.WriteLine(12);
             } 
             catch (Exception e) when (ExpectedIOIssue(e))


### PR DESCRIPTION
This PR addresses a null dereference false positive pattern, which was caused by translation mistake of null check in try block:

For example, in the following snippet
```cs
try            
{                
    if (stream == null)                   
       return;                 
   stream.WriteLine(12);            
} 
```

Before this fix, a null dereference bug was reported on `stream`, regardless of a null check has handled this case.

This is a `leave_s` instruction translation corner case. When we translate the first `leave_s` instruction in this try block, we should connect the null check node to the target instruction only, without connecting to the next instruction.