### PR TITLE
Resolve multiple PR comments

### DIFF
--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -451,6 +451,13 @@ namespace Cilsil.Cil.Parsers
             }
         }
 
+        /// <summary>
+        /// Returns the registered type if the local variable is already registered to the proc 
+        /// attributes.
+        /// </summary>
+        /// <param name="state">Current program state.</param>
+        /// <param name="lvar">Variable to check.</param>
+        /// <returns>The type of the registered local variable; otherwise, returns null</returns>
         protected Typ FindTypeOfLocalVariable(ProgramState state, LocalVariable lvar)
         {
             if (state.ProcDesc.PdAttributes.Locals.Any(l => l.Name == lvar.PvName))

--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -450,5 +450,14 @@ namespace Cilsil.Cil.Parsers
                                                   isConstExpr: false));
             }
         }
+
+        protected Typ FindTypeOfLocalVariable(ProgramState state, LocalVariable lvar)
+        {
+            if (state.ProcDesc.PdAttributes.Locals.Any(l => l.Name == lvar.PvName))
+            {
+                return state.ProcDesc.PdAttributes.Locals.First(l => l.Name == lvar.PvName).Type;;
+            }
+            return null;
+        }
     }
 }

--- a/Cilsil/Cil/Parsers/InstructionParser.cs
+++ b/Cilsil/Cil/Parsers/InstructionParser.cs
@@ -139,9 +139,14 @@ namespace Cilsil.Cil.Parsers
         {
             state.Cfg.RegisterNode(node);
             if (inExceptionNodes)
-                state.PreviousNode.ExceptionNodes.Add(node);
+            {
+                state.AddOffsetToExceptionNodeMapping(node);
+            }
             else
+            {
+                state.AddNodeToExceptionNodeOffsetMapping(node);
                 state.PreviousNode.Successors.Add(node);
+            }
             if (RememberNodeOffset)
             {
                 state.SaveNodeOffset(node, PreviousProgramStack);

--- a/Cilsil/Cil/Parsers/RetParser.cs
+++ b/Cilsil/Cil/Parsers/RetParser.cs
@@ -69,7 +69,14 @@ namespace Cilsil.Cil.Parsers
                                                         StatementNode.StatementNodeKind.ReturnStmt,
                                                         state.ProcDesc);
                         retNode.Instructions.Add(retInstr);
-                        retNode.Successors = new List<CfgNode> { state.ProcDesc.ExitNode };
+                        if (returnValue is ExnExpression)
+                        {
+                            retNode.Successors = new List<CfgNode> { state.ProcDesc.ExceptionSinkNode };
+                        }
+                        else
+                        {
+                            retNode.Successors = new List<CfgNode> { state.ProcDesc.ExitNode };
+                        }
                         RegisterNode(state, retNode);
                     }
                     return true;

--- a/Cilsil/Cil/Parsers/StlocParser.cs
+++ b/Cilsil/Cil/Parsers/StlocParser.cs
@@ -79,12 +79,20 @@ namespace Cilsil.Cil.Parsers
             else
             {
                 var variable = new LocalVariable(LocalName(index), state.Method);
+                var variableType = FindTypeOfLocalVariable(state, variable);
+                if (variableType != null)
+                {
+                    type = variableType;
+                }
+                else
+                {
+                    RegisterLocalVariable(state, variable, type);
+                }
                 var storeValueIntoVariable = new Store(new LvarExpression(variable),
                                                        value,
                                                        type,
                                                        state.CurrentLocation);
                 node = AddMethodBodyInstructionsToCfg(state, storeValueIntoVariable);
-                RegisterLocalVariable(state, variable, type);
                 state.PushInstruction(instruction.Next, node);
             }
 

--- a/Cilsil/Services/CfgParserService.cs
+++ b/Cilsil/Services/CfgParserService.cs
@@ -117,6 +117,9 @@ namespace Cilsil.Services
                             catchType = exceptionHandlingBlock.CatchType;
                             exceptionHandlingBlockStartOffset = exceptionHandlingBlock.HandlerStart.Offset;
                             exceptionHandlingBlockEndOffset = exceptionHandlingBlock.HandlerEnd.Offset;
+                            programState.RegisterTryBlockExceptionHandling(exceptionHandlingBlock.TryStart.Offset, 
+                                                                           exceptionHandlingBlock.TryEnd.Offset,
+                                                                           exceptionHandlingBlockStartOffset);
                             break;
 
                         case ExceptionHandlerType.Finally:
@@ -173,7 +176,12 @@ namespace Cilsil.Services
                 foreach (var node in programState.ProcDesc.Nodes)
                 {
 
-                    if (node.ExceptionNodes.Count == 0)
+                    if (programState.NodeToExceptionNodeOffset.ContainsKey(node))
+                    {
+                        var exceptionNode = programState.OffsetToExceptionNode[programState.NodeToExceptionNodeOffset[node]];
+                        node.ExceptionNodes.Add(exceptionNode);
+                    }
+                    else if (node.ExceptionNodes.Count == 0)
                     {
                         node.ExceptionNodes.Add(programState.ProcDesc.ExceptionSinkNode);
                     }
@@ -193,8 +201,7 @@ namespace Cilsil.Services
                 programState.ProcDesc.ExitNode.ExceptionNodes.Clear();
                 programState.ProcDesc.ExceptionSinkNode.ExceptionNodes.Clear();
                 programState.ProcDesc.StartNode.ExceptionNodes.Add(programState.ProcDesc.ExitNode);
-                programState.ProcDesc.ExceptionSinkNode.ExceptionNodes.Add(
-                    programState.ProcDesc.ExitNode);
+                programState.ProcDesc.ExceptionSinkNode.ExceptionNodes.Add(programState.ProcDesc.ExitNode);
 
                 SetNodePredecessors(programState);
 

--- a/Cilsil/Utils/ProgramState.cs
+++ b/Cilsil/Utils/ProgramState.cs
@@ -93,6 +93,12 @@ namespace Cilsil.Utils
         /// </summary>
         public Dictionary<int, BoxedValueType> VariableIndexToBoxedValueType { get; }
 
+        public Dictionary<int, CfgNode> OffsetToExceptionNode { get; }
+
+        public Dictionary<CfgNode, int> NodeToExceptionNodeOffset { get; }
+
+        private Dictionary<int, int> TryOffsetToCatchOffset;
+
         /// <summary>
         /// Previous expression registered by return node.
         /// </summary>
@@ -170,6 +176,9 @@ namespace Cilsil.Utils
                                          new LocalVariable(Identifier.ReturnIdentifier,
                                                            Method));
             PreviousReturnedType = Typ.FromTypeReference(Method.ReturnType);
+            OffsetToExceptionNode = new Dictionary<int, CfgNode>();
+            NodeToExceptionNodeOffset = new Dictionary<CfgNode, int>();
+            TryOffsetToCatchOffset = new Dictionary<int, int>();
         }
 
         /// <summary>
@@ -444,6 +453,28 @@ namespace Cilsil.Utils
             else
             {
                 return string.Empty;
+            }
+        }
+
+        public void RegisterTryBlockExceptionHandling(int tryStartOffset, int tryEndOffset, int exceptionBlockStartOffset)
+        {
+            foreach (int offset in Enumerable.Range(tryStartOffset, tryEndOffset - 1))
+            {
+                TryOffsetToCatchOffset[offset] = exceptionBlockStartOffset;
+            } 
+        }
+
+        public void AddOffsetToExceptionNodeMapping(CfgNode node)
+        {
+            OffsetToExceptionNode[CurrentInstruction.Offset] = node;
+        }
+
+        public void AddNodeToExceptionNodeOffsetMapping(CfgNode node)
+        {
+            if (TryOffsetToCatchOffset.ContainsKey(CurrentInstruction.Offset))
+            {
+                var exceptionNodeOffset = TryOffsetToCatchOffset[CurrentInstruction.Offset];
+                NodeToExceptionNodeOffset[node] = exceptionNodeOffset;
             }
         }
 


### PR DESCRIPTION
This PR addresses the following exception handling PR comments:

1. Try block nodes should connect to the first catch block node as their exception nodes. (fixed in this [commit)](https://github.com/xi-liu-ds/infersharp/commit/a0a673ad954446d0ab2eccb3d3c9e3913ff19bab)
2. Registered local variables should be associated with consistent data types (fixed in this [commit](https://github.com/xi-liu-ds/infersharp/commit/fa5762575a030262cbc3c65f35fbda26cc096df9))
3.  return exn node should exit at exception sink node (fixed in this [commit](https://github.com/xi-liu-ds/infersharp/commit/7cbaaedcbc477986fcf2b19d94273f283126821e))